### PR TITLE
Dependency addition Python3

### DIFF
--- a/xo_install.sh
+++ b/xo_install.sh
@@ -43,7 +43,7 @@ n lts
 ln -s /usr/bin/node /usr/local/bin/node
 
 # Install XO dependencies
-/usr/bin/apt-get install --yes build-essential redis-server libpng-dev git python2-minimal libvhdi-utils nfs-common lvm2 cifs-utils
+/usr/bin/apt-get install --yes build-essential redis-server libpng-dev git python3-minimal libvhdi-utils nfs-common lvm2 cifs-utils
 
 /usr/bin/git clone -b $xo_branch $xo_server
 

--- a/xo_install.sh
+++ b/xo_install.sh
@@ -43,7 +43,7 @@ n lts
 ln -s /usr/bin/node /usr/local/bin/node
 
 # Install XO dependencies
-/usr/bin/apt-get install --yes build-essential redis-server libpng-dev git python-minimal libvhdi-utils nfs-common lvm2 cifs-utils python2-minimal
+/usr/bin/apt-get install --yes build-essential redis-server libpng-dev git python2-minimal libvhdi-utils nfs-common lvm2 cifs-utils
 
 /usr/bin/git clone -b $xo_branch $xo_server
 

--- a/xo_install.sh
+++ b/xo_install.sh
@@ -22,7 +22,7 @@ xo_service="xo-server.service"
 
 # Ensures that Yarn dependencies are installed
 /usr/bin/apt-get update
-/usr/bin/apt-get --yes install git curl apt-transport-https gnupg python2-minimal
+/usr/bin/apt-get --yes install git curl apt-transport-https gnupg
 
 #Install yarn
 cd /opt
@@ -43,7 +43,7 @@ n lts
 ln -s /usr/bin/node /usr/local/bin/node
 
 # Install XO dependencies
-/usr/bin/apt-get install --yes build-essential redis-server libpng-dev git python-minimal libvhdi-utils nfs-common lvm2 cifs-utils 
+/usr/bin/apt-get install --yes build-essential redis-server libpng-dev git python-minimal libvhdi-utils nfs-common lvm2 cifs-utils python2-minimal
 
 /usr/bin/git clone -b $xo_branch $xo_server
 

--- a/xo_install.sh
+++ b/xo_install.sh
@@ -22,7 +22,7 @@ xo_service="xo-server.service"
 
 # Ensures that Yarn dependencies are installed
 /usr/bin/apt-get update
-/usr/bin/apt-get --yes install git curl apt-transport-https gnupg
+/usr/bin/apt-get --yes install git curl apt-transport-https gnupg python2-minimal
 
 #Install yarn
 cd /opt


### PR DESCRIPTION
Python2 was removed from at least 20.04 and is replaced with Python3. Manually installing the package and then running the script works. 

This change runs the installation process for it.